### PR TITLE
Dynamic metrics for cpu and net statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,28 @@ This plugin has the ability to gather the following metrics:
 
 Namespace | Description (optional)
 ----------|-----------------------
-/intel/psutil/[CPU]/guest | time spent in guest mode
-/intel/psutil/[CPU]/guest_nice | time spent running a niced guest (virtual CPU for guest operating systems under the control of the Linux kernel)
-/intel/psutil/[CPU]/idle | time spent in the idle task.  This value should be USER_HZ times the second entry in the /proc/uptime pseudo-file
-/intel/psutil/[CPU]/iowait | time waiting for I/O to complete
-/intel/psutil/[CPU]/irq | time servicing interrupts
-/intel/psutil/[CPU]/nice | time spent in user mode with low priority (nice)
-/intel/psutil/[CPU]/softirq | time spent servicing softirqs
-/intel/psutil/[CPU]/steal | stolen time, which is the time spent in other operating systems when running in a virtualized environment
-/intel/psutil/[CPU]/stolen |
-/intel/psutil/[CPU]/system | time spent in system mode
-/intel/psutil/[CPU]/user | time spent in user mode
+/intel/psutil/cpu/cpu-total/guest | time spent in guest mode accumulated over all cpus
+/intel/psutil/cpu/cpu-total/guest_nice | time spent running a niced guest (virtual CPU for guest operating systems under the control of the Linux kernel) accumulated over all cpus
+/intel/psutil/cpu/cpu-total/idle | time spent in the idle task accumulated over all cpus.  This value should be USER_HZ times the second entry in the /proc/uptime pseudo-file
+/intel/psutil/cpu/cpu-total/iowait | time waiting for I/O to complete accumulated over all cpus
+/intel/psutil/cpu/cpu-total/irq | time servicing interrupts accumulated over all cpus
+/intel/psutil/cpu/cpu-total/nice | time spent in user mode with low priority (nice) accumulated over all cpus
+/intel/psutil/cpu/cpu-total/softirq | time spent servicing softirqs accumulated over all cpus
+/intel/psutil/cpu/cpu-total/steal | stolen time, which is the time spent in other operating systems when running in a virtualized environment accumulated over all cpus
+/intel/psutil/cpu/cpu-total/stolen |
+/intel/psutil/cpu/cpu-total/system | time spent in system mode accumulated over all cpus
+/intel/psutil/cpu/cpu-total/user | time spent in user mode accumulated over all cpus
+/intel/psutil/cpu/[CPU]/guest | time spent in guest mode
+/intel/psutil/cpu/[CPU]/guest_nice | time spent running a niced guest (virtual CPU for guest operating systems under the control of the Linux kernel)
+/intel/psutil/cpu/[CPU]/idle | time spent in the idle task.  This value should be USER_HZ times the second entry in the /proc/uptime pseudo-file
+/intel/psutil/cpu/[CPU]/iowait | time waiting for I/O to complete
+/intel/psutil/cpu/[CPU]/irq | time servicing interrupts
+/intel/psutil/cpu/[CPU]/nice | time spent in user mode with low priority (nice)
+/intel/psutil/cpu/[CPU]/softirq | time spent servicing softirqs
+/intel/psutil/cpu/[CPU]/steal | stolen time, which is the time spent in other operating systems when running in a virtualized environment
+/intel/psutil/cpu/[CPU]/stolen |
+/intel/psutil/cpu/[CPU]/system | time spent in system mode
+/intel/psutil/cpu/[CPU]/user | time spent in user mode
 |
 /intel/psutil/load/load1 | load average over the last 1 minute
 /intel/psutil/load/load15 | load average over the last 15 minutes
@@ -90,14 +101,14 @@ Namespace | Description (optional)
 /intel/psutil/net/all/errout | total number of errors while sending
 /intel/psutil/net/all/packets_recv | number of packets received
 /intel/psutil/net/all/packets_sent | number of packets sent
-/intel/psutil/net/[INTERFACE]/bytes_recv |
-/intel/psutil/net/[INTERFACE]/bytes_sent |
-/intel/psutil/net/[INTERFACE]/dropin |
-/intel/psutil/net/[INTERFACE]/dropout |
-/intel/psutil/net/[INTERFACE]/errin |
-/intel/psutil/net/[INTERFACE]/errout |
-/intel/psutil/net/[INTERFACE]/packets_recv |
-/intel/psutil/net/[INTERFACE]/packets_sent |
+/intel/psutil/net/[INTERFACE]/bytes_recv | number of bytes sent on given interface
+/intel/psutil/net/[INTERFACE]/bytes_sent | number of bytes received on given interface
+/intel/psutil/net/[INTERFACE]/dropin | total number of incoming packets which were dropped on given interface
+/intel/psutil/net/[INTERFACE]/dropout | total number of outgoing packets which were dropped (always 0 on OSX and BSD) o given interface
+/intel/psutil/net/[INTERFACE]/errin | total number of errors while receiving on given interface
+/intel/psutil/net/[INTERFACE]/errout | total number of errors while sending on given interface
+/intel/psutil/net/[INTERFACE]/packets_recv | number of packets received on given interface
+/intel/psutil/net/[INTERFACE]/packets_sent | number of packets sent on given interface
 |
 /intel/psutil/vm/active | memory currently in use or very recently used, and so it is in RAM
 /intel/psutil/vm/available | the actual amount of available memory that can be given instantly to processes that request more memory in bytes; this is calculated by summing different memory values depending on the platform (e.g. free + buffers + cached on Linux) and it is supposed to be used to monitor actual memory usage in a cross platform fashion
@@ -145,6 +156,8 @@ Create a task manifest file (e.g. `task-psutil.json`):
                 "/intel/psutil/load/load1": {},
                 "/intel/psutil/load/load5": {},
                 "/intel/psutil/load/load15": {},
+                "/intel/psutil/cpu/*/user": {},
+                "/intel/psutil/net/*/bytes_sent": {},
                 "/intel/psutil/vm/available": {},
                 "/intel/psutil/vm/free": {},
                 "/intel/psutil/vm/used": {}

--- a/examples/tasks/mock-psutil.sh
+++ b/examples/tasks/mock-psutil.sh
@@ -16,9 +16,9 @@ PLUGIN_PATH=${PLUGIN_PATH:-"${TMPDIR}/snap/plugins"}
 mkdir -p $PLUGIN_PATH
 
 _info "downloading plugins"
-(cd $PLUGIN_PATH && curl -sSO http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-publisher-mock-file && chmod 755 snap-plugin-publisher-mock-file)
-(cd $PLUGIN_PATH && curl -sSO http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-processor-passthru && chmod 755 snap-plugin-processor-passthru)
-(cd $PLUGIN_PATH && curl -sSO http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-psutil/latest/linux/x86_64/snap-plugin-collector-psutil && chmod 755 snap-plugin-collector-psutil)
+(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-publisher-mock-file && chmod 755 snap-plugin-publisher-mock-file)
+(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-processor-passthru && chmod 755 snap-plugin-processor-passthru)
+(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-psutil/latest_build/linux/x86_64/snap-plugin-collector-psutil && chmod 755 snap-plugin-collector-psutil)
 
 SNAP_FLAG=0
 

--- a/examples/tasks/run-mock-psutil.sh
+++ b/examples/tasks/run-mock-psutil.sh
@@ -17,5 +17,10 @@ export PLUGIN_SRC="${__proj_dir}"
 
 # downloads plugins, starts snap, load plugins and start a task
 __id=$(docker run -e SNAP_VERSION=latest -d -v ${PLUGIN_SRC}:/${__proj_name} --net=host intelsdi/snap:alpine)
+# clean up containers on exit
+function finish {
+  (docker kill ${__id})
+}
+trap finish EXIT INT TERM
+
 docker exec -it ${__id} bash -c "PLUGIN_PATH=/etc/snap/plugins /${__proj_name}/examples/tasks/mock-psutil.sh && printf \"\n\nhint: type 'snapctl task list'\ntype 'exit' when your done\n\n\" && bash"
-docker kill ${__id}

--- a/psutil/load.go
+++ b/psutil/load.go
@@ -20,6 +20,7 @@ package psutil
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/core"
@@ -41,18 +42,21 @@ func loadAvg(nss []core.Namespace) ([]plugin.MetricType, error) {
 				Namespace_: ns,
 				Data_:      load.Load1,
 				Unit_:      "Load/1M",
+				Timestamp_: time.Now(),
 			}
 		case "load5":
 			results[i] = plugin.MetricType{
 				Namespace_: ns,
 				Data_:      load.Load5,
 				Unit_:      "Load/5M",
+				Timestamp_: time.Now(),
 			}
 		case "load15":
 			results[i] = plugin.MetricType{
 				Namespace_: ns,
 				Data_:      load.Load15,
 				Unit_:      "Load/15M",
+				Timestamp_: time.Now(),
 			}
 		default:
 			return nil, fmt.Errorf("Requested load statistic %s is not found", ns.Element(len(ns)-1).Value)

--- a/psutil/load.go
+++ b/psutil/load.go
@@ -26,34 +26,40 @@ import (
 	"github.com/shirou/gopsutil/load"
 )
 
-func loadAvg(ns core.Namespace) (*plugin.MetricType, error) {
+func loadAvg(nss []core.Namespace) ([]plugin.MetricType, error) {
 	load, err := load.Avg()
 	if err != nil {
 		return nil, err
 	}
 
-	switch ns.String() {
-	case "/intel/psutil/load/load1":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      load.Load1,
-			Unit_:      "Load/1M",
-		}, nil
-	case "/intel/psutil/load/load5":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      load.Load5,
-			Unit_:      "Load/5M",
-		}, nil
-	case "/intel/psutil/load/load15":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      load.Load15,
-			Unit_:      "Load/15M",
-		}, nil
+	results := make([]plugin.MetricType, len(nss))
+
+	for i, ns := range nss {
+		switch ns.Element(len(ns) - 1).Value {
+		case "load1":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      load.Load1,
+				Unit_:      "Load/1M",
+			}
+		case "load5":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      load.Load5,
+				Unit_:      "Load/5M",
+			}
+		case "load15":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      load.Load15,
+				Unit_:      "Load/15M",
+			}
+		default:
+			return nil, fmt.Errorf("Requested load statistic %s is not found", ns.Element(len(ns)-1).Value)
+		}
 	}
 
-	return nil, fmt.Errorf("Unknown error processing %v", ns)
+	return results, nil
 }
 
 func getLoadAvgMetricTypes() []plugin.MetricType {

--- a/psutil/mem.go
+++ b/psutil/mem.go
@@ -20,6 +20,7 @@ package psutil
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/core"
@@ -35,69 +36,38 @@ func virtualMemory(nss []core.Namespace) ([]plugin.MetricType, error) {
 	results := make([]plugin.MetricType, len(nss))
 
 	for i, ns := range nss {
+		var data interface{}
 
 		switch ns.Element(len(ns) - 1).Value {
 		case "total":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Total,
-				Unit_:      "B",
-			}
+			data = mem.Total
 		case "available":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Available,
-				Unit_:      "B",
-			}
+			data = mem.Available
 		case "used":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Used,
-				Unit_:      "B",
-			}
+			data = mem.Used
 		case "used_percent":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.UsedPercent,
-			}
+			data = mem.UsedPercent
 		case "free":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Free,
-				Unit_:      "B",
-			}
+			data = mem.Free
 		case "active":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Active,
-				Unit_:      "B",
-			}
+			data = mem.Active
 		case "inactive":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Inactive,
-				Unit_:      "B",
-			}
+			data = mem.Inactive
 		case "buffers":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Buffers,
-				Unit_:      "B",
-			}
+			data = mem.Buffers
 		case "cached":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Cached,
-				Unit_:      "B",
-			}
+			data = mem.Cached
 		case "wired":
-			results[i] = plugin.MetricType{
-				Namespace_: ns,
-				Data_:      mem.Wired,
-				Unit_:      "B",
-			}
+			data = mem.Wired
 		default:
 			return nil, fmt.Errorf("Requested memory statistic %s is not found", ns.String())
+		}
+
+		results[i] = plugin.MetricType{
+			Namespace_: ns,
+			Data_:      data,
+			Unit_:      "B",
+			Timestamp_: time.Now(),
 		}
 	}
 

--- a/psutil/mem.go
+++ b/psutil/mem.go
@@ -26,75 +26,82 @@ import (
 	"github.com/shirou/gopsutil/mem"
 )
 
-func virtualMemory(ns core.Namespace) (*plugin.MetricType, error) {
+func virtualMemory(nss []core.Namespace) ([]plugin.MetricType, error) {
 	mem, err := mem.VirtualMemory()
 	if err != nil {
 		return nil, err
 	}
 
-	switch ns.String() {
-	case "/intel/psutil/vm/total":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Total,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/available":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Available,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/used":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Used,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/used_percent":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.UsedPercent,
-		}, nil
-	case "/intel/psutil/vm/free":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Free,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/active":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Active,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/inactive":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Inactive,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/buffers":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Buffers,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/cached":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Cached,
-			Unit_:      "B",
-		}, nil
-	case "/intel/psutil/vm/wired":
-		return &plugin.MetricType{
-			Namespace_: ns,
-			Data_:      mem.Wired,
-			Unit_:      "B",
-		}, nil
+	results := make([]plugin.MetricType, len(nss))
+
+	for i, ns := range nss {
+
+		switch ns.Element(len(ns) - 1).Value {
+		case "total":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Total,
+				Unit_:      "B",
+			}
+		case "available":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Available,
+				Unit_:      "B",
+			}
+		case "used":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Used,
+				Unit_:      "B",
+			}
+		case "used_percent":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.UsedPercent,
+			}
+		case "free":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Free,
+				Unit_:      "B",
+			}
+		case "active":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Active,
+				Unit_:      "B",
+			}
+		case "inactive":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Inactive,
+				Unit_:      "B",
+			}
+		case "buffers":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Buffers,
+				Unit_:      "B",
+			}
+		case "cached":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Cached,
+				Unit_:      "B",
+			}
+		case "wired":
+			results[i] = plugin.MetricType{
+				Namespace_: ns,
+				Data_:      mem.Wired,
+				Unit_:      "B",
+			}
+		default:
+			return nil, fmt.Errorf("Requested memory statistic %s is not found", ns.String())
+		}
 	}
 
-	return nil, fmt.Errorf("Unknown error processing %v", ns)
+	return results, nil
 }
 
 func getVirtualMemoryMetricTypes() []plugin.MetricType {

--- a/psutil/psutil.go
+++ b/psutil/psutil.go
@@ -20,7 +20,6 @@ package psutil
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/intelsdi-x/snap/control/plugin"
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
@@ -49,28 +48,24 @@ type Psutil struct {
 
 // CollectMetrics returns metrics from gopsutil
 func (p *Psutil) CollectMetrics(mts []plugin.MetricType) ([]plugin.MetricType, error) {
-	loadre := regexp.MustCompile(`^/intel/psutil/load/.*`)
-	cpure := regexp.MustCompile(`^/intel/psutil/cpu/.*`)
-	memre := regexp.MustCompile(`^/intel/psutil/vm/.*`)
-	netre := regexp.MustCompile(`^/intel/psutil/net/.*`)
-
 	loadReqs := []core.Namespace{}
 	cpuReqs := []core.Namespace{}
 	memReqs := []core.Namespace{}
 	netReqs := []core.Namespace{}
 
-	for _, p := range mts {
-		switch {
-		case loadre.MatchString(p.Namespace().String()):
-			loadReqs = append(loadReqs, p.Namespace())
-		case cpure.MatchString(p.Namespace().String()):
-			cpuReqs = append(cpuReqs, p.Namespace())
-		case memre.MatchString(p.Namespace().String()):
-			memReqs = append(memReqs, p.Namespace())
-		case netre.MatchString(p.Namespace().String()):
-			netReqs = append(netReqs, p.Namespace())
+	for _, m := range mts {
+		ns := m.Namespace()
+		switch ns[2].Value {
+		case "load":
+			loadReqs = append(loadReqs, ns)
+		case "cpu":
+			cpuReqs = append(cpuReqs, ns)
+		case "vm":
+			memReqs = append(memReqs, ns)
+		case "net":
+			netReqs = append(netReqs, ns)
 		default:
-			return nil, fmt.Errorf("Requested metric %s does not match any known psutil metric", p.Namespace().String())
+			return nil, fmt.Errorf("Requested metric %s does not match any known psutil metric", m.Namespace().String())
 		}
 	}
 

--- a/psutil/psutil_integration_test.go
+++ b/psutil/psutil_integration_test.go
@@ -50,7 +50,7 @@ func TestPsutilCollectMetrics(t *testing.T) {
 			}
 			if runtime.GOOS != "darwin" {
 				mts = append(mts, plugin.MetricType{
-					Namespace_: core.NewNamespace("intel", "psutil", "cpu0", "user"),
+					Namespace_: core.NewNamespace("intel", "psutil", "cpu", "cpu0", "user"),
 				})
 			}
 			metrics, err := p.CollectMetrics(mts)

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -33,7 +33,7 @@ class PsutilCollectorLargeTest(unittest.TestCase):
 
         snapd_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapd"
         snapctl_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapctl"
-        psutil_url = "http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-psutil/latest/linux/x86_64/snap-plugin-collector-psutil"
+        psutil_url = "http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-psutil/latest_build/linux/x86_64/snap-plugin-collector-psutil"
         passthru_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-processor-passthru"
         mockfile_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-publisher-mock-file"
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Introduces dynamic metrics to cpu and net statistics

Summary of changes:
- cpu ids are now presented as dynamic metric
- interface ids are now presented as dynamic metric
- calls to gopsutil functions done only once per collect (not for each requested metric)
- updated docs

How to verify it:
- execute example task

Testing done:
- units
- manual

@intelsdi-x/plugin-maintainers 