### PR TITLE
Plugin mount path in docker as env var

### DIFF
--- a/examples/tasks/mock-psutil.sh
+++ b/examples/tasks/mock-psutil.sh
@@ -23,7 +23,7 @@ _info "downloading plugins"
 SNAP_FLAG=0
 
 # this block will wait check if snapctl and snapd are loaded before the plugins are loaded and the task is started
- for i in `seq 1 5`; do
+ for i in `seq 1 10`; do
              if [[ -f /usr/local/bin/snapctl && -f /usr/local/bin/snapd ]];
                 then
 
@@ -40,8 +40,8 @@ SNAP_FLAG=0
                     break
              fi 
         
-        _info "snapctl and/or snapd are unavailable, sleeping for 3 seconds" 
-        sleep 3
+        _info "snapctl and/or snapd are unavailable, sleeping for 5 seconds"
+        sleep 5
 done 
 
 

--- a/scripts/docker/large/docker-compose.yml
+++ b/scripts/docker/large/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     image: python:2.7.12-alpine
     network_mode: "host"
     volumes:
-      - ${PLUGIN_SRC}:/snap-plugin-collector-psutil
+      - ${PLUGIN_SRC}:/${PROJECT_NAME}
     entrypoint: sh -c 'python /snap-plugin-collector-psutil/scripts/test/large.py'
+    environment:
+      PROJECT_NAME: ${PROJECT_NAME}

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -41,13 +41,13 @@ class PsutilCollectorLargeTest(unittest.TestCase):
         self.binaries = bins.Binaries()
         self.binaries.snapd = bins.Snapd(snapd_url, snap_dir)
         self.binaries.snapctl = bins.Snapctl(snapctl_url, snap_dir)
-        self.binaries.collector = bins.Plugin(psutil_url, plugins_dir, "collector", 6)
+        self.binaries.collector = bins.Plugin(psutil_url, plugins_dir, "collector", 7)
         self.binaries.processor = bins.Plugin(passthru_url, plugins_dir, "processor", -1)
         self.binaries.publisher = bins.Plugin(mockfile_url, plugins_dir, "publisher", -1)
 
         utils.download_binaries(self.binaries)
 
-        self.task_file = "/snap-plugin-collector-psutil/examples/tasks/task-psutil.json"
+        self.task_file = "/{}/examples/tasks/task-psutil.json".format(os.getenv("PROJECT_NAME", "/snap-plugin-collector-psutil"))
 
         log.info("starting snapd")
         self.binaries.snapd.start()
@@ -107,7 +107,8 @@ class PsutilCollectorLargeTest(unittest.TestCase):
         self.assertEqual(len(plugins), 2, "Plugins available {} expected {}".format(len(plugins), 2))
 
         # check for snapd errors
-        self.assertEqual(len(self.binaries.snapd.errors), 0, "Errors found during snapd execution")
+        self.assertEqual(len(self.binaries.snapd.errors), 0, "Errors found during snapd execution:\n{}"
+                         .format("\n".join(self.binaries.snapd.errors)))
 
     def tearDown(self):
         log.info("stopping snapd")


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Plugin mount path is configurable by environment variable now

Summary of changes:
- docker-compose.yml uses env var as mount point
- large.py uses env var to find task location

How to verify it:
- run large tests

Testing done:
- large tests