### PR TITLE
Env vars for task, plugins and snap path

### DIFF
--- a/scripts/large_k8s.sh
+++ b/scripts/large_k8s.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#
+#Copyright 2016 Intel Corporation
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+__proj_dir="$(dirname "$__dir")"
+__proj_name="$(basename $__proj_dir)"
+
+. "${__dir}/common.sh"
+
+_info "DIR=${__dir}"
+_info "PROJ_DIR=${__proj_dir}"
+_info "PROJ_NAME${__proj_name}"
+
+#_info "updating repository submodule with pytest"
+cd ${__proj_dir} && git submodule update --init --recursive
+
+export PROJECT_NAME="${__proj_name}"
+
+#_info "execute large test"
+test_result=`python "${__proj_dir}/scripts/test/large.py"`
+exit $test_result

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -28,8 +28,8 @@ from unittest import TextTestRunner
 class PsutilCollectorLargeTest(unittest.TestCase):
 
     def setUp(self):
-        plugins_dir = "/etc/snap/plugins"
-        snap_dir = "/usr/local/bin"
+        plugins_dir = os.getenv("PLUGINS_DIR", "/etc/snap/plugins")
+        snap_dir = os.getenv("SNAP_DIR", "/usr/local/bin")
 
         snapd_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapd"
         snapctl_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapctl"
@@ -47,7 +47,7 @@ class PsutilCollectorLargeTest(unittest.TestCase):
 
         utils.download_binaries(self.binaries)
 
-        self.task_file = "/{}/examples/tasks/task-psutil.json".format(os.getenv("PROJECT_NAME", "/snap-plugin-collector-psutil"))
+        self.task_file = "/{}/examples/tasks/task-psutil.json".format(os.getenv("PROJECT_NAME", "snap-plugin-collector-psutil"))
 
         log.info("starting snapd")
         self.binaries.snapd.start()


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Provides env variables for setting path

Summary of changes:
- path to task manifest 
- path to snap
- path to plugins

How to verify it:
- run large tests

Testing done:
- large tests
- minikube 

