### PR TITLE
Submodule removed, updated to large tests, glide.lock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "scripts/test/pytest"]
-	path = scripts/test/pytest
-	url = https://github.com/marcin-krolik/snap-pytest

--- a/examples/tasks/.setup.sh
+++ b/examples/tasks/.setup.sh
@@ -4,8 +4,6 @@ set -e
 set -u
 set -o pipefail
 
-git submodule update --init --recursive
-
 # check for dependencies
 EXIT_ON_ERROR=0
 command -v docker >/dev/null 2>&1 || { echo >&2 "Error: docker needs to be installed."; EXIT_ON_ERROR=1; }

--- a/examples/tasks/mock-psutil.sh
+++ b/examples/tasks/mock-psutil.sh
@@ -16,8 +16,8 @@ PLUGIN_PATH=${PLUGIN_PATH:-"${TMPDIR}/snap/plugins"}
 mkdir -p $PLUGIN_PATH
 
 _info "downloading plugins"
-(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-publisher-mock-file && chmod 755 snap-plugin-publisher-mock-file)
-(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-processor-passthru && chmod 755 snap-plugin-processor-passthru)
+(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-publisher-mock-file && chmod 755 snap-plugin-publisher-mock-file)
+(cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-processor-passthru && chmod 755 snap-plugin-processor-passthru)
 (cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-psutil/latest_build/linux/x86_64/snap-plugin-collector-psutil && chmod 755 snap-plugin-collector-psutil)
 
 SNAP_FLAG=0

--- a/examples/tasks/run-mock-psutil.sh
+++ b/examples/tasks/run-mock-psutil.sh
@@ -16,7 +16,7 @@ export PLUGIN_SRC="${__proj_dir}"
 . "${__proj_dir}/examples/tasks/.setup.sh"
 
 # downloads plugins, starts snap, load plugins and start a task
-__id=$(docker run -e SNAP_VERSION=latest -d -v ${PLUGIN_SRC}:/${__proj_name} --net=host intelsdi/snap:alpine)
+__id=$(docker run -e SNAP_VERSION=latest -d -v ${PLUGIN_SRC}:/${__proj_name} --net=host mkrolik/snap-pytest)
 # clean up containers on exit
 function finish {
   (docker kill ${__id})

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,13 +1,9 @@
 package: github.com/intelsdi-x/snap-plugin-collector-psutil
 import:
-- package: github.com/shirou/gopsutil
-  subpackages:
-  - cpu
-  - load
-  - mem
-  - net
 - package: github.com/intelsdi-x/snap
   version: e3164017505aa87d70fa9248769c8b6edc13ac08
+- package: github.com/shirou/gopsutil
+  version: fc800d3fb423e37fe8e44338e380bc6b551dcf36
 testImport:
 - package: github.com/smartystreets/goconvey
   subpackages:

--- a/scripts/docker/large/docker-compose.yml
+++ b/scripts/docker/large/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   main:
     container_name: psutil_large_test
-    image: python:2.7.12-alpine
+    image: mkrolik/spytest
     network_mode: "host"
     volumes:
       - ${PLUGIN_SRC}:/${PROJECT_NAME}

--- a/scripts/large_compose.sh
+++ b/scripts/large_compose.sh
@@ -41,9 +41,6 @@ _docker_project () {
   cd "${docker_folder}" && "$@"
 }
 
-_debug "updating repository submodule with pytest"
-git submodule update --init --recursive
-
 _debug "building docker compose images"
 _docker_project docker-compose build
 _debug "running test: ${TEST_TYPE}"

--- a/scripts/large_test.sh
+++ b/scripts/large_test.sh
@@ -27,9 +27,6 @@ __proj_name="$(basename $__proj_dir)"
 
 . "${__dir}/common.sh"
 
-#_info "updating repository submodule with pytest"
-cd ${__proj_dir} && git submodule update --init --recursive
-
 export PROJECT_DIR="${__proj_dir}"
 
 #_info "execute large test"

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -19,9 +19,9 @@ import sys
 import os
 import unittest
 
-from pytest import bins
-from pytest import utils
-from pytest.logger import log
+from spytest import bins
+from spytest import utils
+from spytest.logger import log
 from unittest import TextTestRunner
 
 
@@ -31,11 +31,11 @@ class PsutilCollectorLargeTest(unittest.TestCase):
         plugins_dir = os.getenv("PLUGINS_DIR", "/etc/snap/plugins")
         snap_dir = os.getenv("SNAP_DIR", "/usr/local/bin")
 
-        snapd_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapd"
-        snapctl_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snapctl"
+        snapd_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapd"
+        snapctl_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapctl"
         psutil_url = "http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-psutil/latest_build/linux/x86_64/snap-plugin-collector-psutil"
-        passthru_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-processor-passthru"
-        mockfile_url = "http://snap.ci.snap-telemetry.io/snap/master/latest/snap-plugin-publisher-mock-file"
+        passthru_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-processor-passthru"
+        mockfile_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-publisher-mock-file"
 
         # set and download required binaries (snapd, snapctl, plugins)
         self.binaries = bins.Binaries()


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Summary of changes:
- removed submodule repo
- `spytest` pip package used for large tests
- `glide.yml` updated with latest commit of `gopsutil`
- updated S3 paths to binaries

How to verify it:
- large tests
- run example

Testing done:
- large tests
