### PR TITLE
Snap binary changed to snaptel/snapteld

### DIFF
--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -15,7 +15,7 @@ Running the sample is as *easy* as running the script `./run-mock-psutil.sh`.
 - [run-mock-psutil.sh](run-mock-psutil.sh) 
     - The example is launched with this script
 - [mock-psutil.sh](mock-psutil.sh)
-    - Downloads `snapd`, `snapctl`, `snap-plugin-collector-psutil`,
+    - Downloads `snapteld`, `snaptel`, `snap-plugin-collector-psutil`,
     `snap-plugin-publisher-mock-file`, `snap-plugin-processor-passthru` and starts the task
     [task-psutil.json](task-mpsutil.json).
 - [task-psutil.json](task-psutil.json)

--- a/examples/tasks/mock-psutil.sh
+++ b/examples/tasks/mock-psutil.sh
@@ -22,32 +22,32 @@ _info "downloading plugins"
 
 SNAP_FLAG=0
 
-# this block will wait check if snapctl and snapd are loaded before the plugins are loaded and the task is started
+# this block will wait check if snaptel and snapteld are loaded before the plugins are loaded and the task is started
  for i in `seq 1 10`; do
-             if [[ -f /usr/local/bin/snapctl && -f /usr/local/bin/snapd ]];
+             if [[ -f /usr/local/bin/snaptel && -f /usr/local/sbin/snapteld ]];
                 then
 
                     _info "loading plugins"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-publisher-mock-file"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-collector-psutil"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-processor-passthru"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-publisher-mock-file"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-collector-psutil"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-processor-passthru"
 
                     _info "creating and starting a task"
-                    snapctl task create -t "${__dir}/task-psutil.json"
+                    snaptel task create -t "${__dir}/task-psutil.json"
 
                     SNAP_FLAG=1
 
                     break
              fi 
         
-        _info "snapctl and/or snapd are unavailable, sleeping for 5 seconds"
+        _info "snaptel and/or snapteld are unavailable, sleeping for 5 seconds"
         sleep 5
 done 
 
 
-# check if snapctl/snapd have loaded
+# check if snaptel/snapteld have loaded
 if [ $SNAP_FLAG -eq 0 ]
     then
-     echo "Could not load snapctl or snapd"
+     echo "Could not load snaptel or snapteld"
      exit 1
 fi

--- a/examples/tasks/run-mock-psutil.sh
+++ b/examples/tasks/run-mock-psutil.sh
@@ -23,4 +23,4 @@ function finish {
 }
 trap finish EXIT INT TERM
 
-docker exec -it ${__id} bash -c "PLUGIN_PATH=/etc/snap/plugins /${__proj_name}/examples/tasks/mock-psutil.sh && printf \"\n\nhint: type 'snapctl task list'\ntype 'exit' when your done\n\n\" && bash"
+docker exec -it ${__id} bash -c "PLUGIN_PATH=/etc/snap/plugins /${__proj_name}/examples/tasks/mock-psutil.sh && printf \"\n\nhint: type 'snaptel task list'\ntype 'exit' when your done\n\n\" && bash"

--- a/scripts/test/large.py
+++ b/scripts/test/large.py
@@ -31,16 +31,16 @@ class PsutilCollectorLargeTest(unittest.TestCase):
         plugins_dir = os.getenv("PLUGINS_DIR", "/etc/snap/plugins")
         snap_dir = os.getenv("SNAP_DIR", "/usr/local/bin")
 
-        snapd_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapd"
-        snapctl_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapctl"
+        snapteld_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snapteld"
+        snaptel_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snaptel"
         psutil_url = "http://snap.ci.snap-telemetry.io/plugins/snap-plugin-collector-psutil/latest_build/linux/x86_64/snap-plugin-collector-psutil"
         passthru_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-processor-passthru"
         mockfile_url = "http://snap.ci.snap-telemetry.io/snap/latest_build/linux/x86_64/snap-plugin-publisher-mock-file"
 
-        # set and download required binaries (snapd, snapctl, plugins)
+        # set and download required binaries (snapteld, snaptel, plugins)
         self.binaries = bins.Binaries()
-        self.binaries.snapd = bins.Snapd(snapd_url, snap_dir)
-        self.binaries.snapctl = bins.Snapctl(snapctl_url, snap_dir)
+        self.binaries.snapteld = bins.Snapteld(snapteld_url, snap_dir)
+        self.binaries.snaptel = bins.Snaptel(snaptel_url, snap_dir)
         self.binaries.collector = bins.Plugin(psutil_url, plugins_dir, "collector", 8)
         self.binaries.processor = bins.Plugin(passthru_url, plugins_dir, "processor", -1)
         self.binaries.publisher = bins.Plugin(mockfile_url, plugins_dir, "publisher", -1)
@@ -49,72 +49,72 @@ class PsutilCollectorLargeTest(unittest.TestCase):
 
         self.task_file = "{}/examples/tasks/task-psutil.json".format(os.getenv("PROJECT_DIR", "/snap-plugin-collector-psutil"))
 
-        log.info("starting snapd")
-        self.binaries.snapd.start()
-        if not self.binaries.snapd.isAlive():
-            self.fail("snapd thread died")
+        log.info("starting snapteld")
+        self.binaries.snapteld.start()
+        if not self.binaries.snapteld.isAlive():
+            self.fail("snapteld thread died")
 
-        log.debug("Waiting for snapd to finish starting")
-        if not self.binaries.snapd.wait():
-            log.error("snapd errors: {}".format(self.binaries.snapd.errors))
-            self.binaries.snapd.kill()
-            self.fail("snapd not ready, timeout!")
+        log.debug("Waiting for snapteld to finish starting")
+        if not self.binaries.snapteld.wait():
+            log.error("snapteld errors: {}".format(self.binaries.snapteld.errors))
+            self.binaries.snapteld.kill()
+            self.fail("snapteld not ready, timeout!")
 
     def test_psutil_collector_plugin(self):
         # load plugins
         for plugin in self.binaries.get_all_plugins():
-            log.info("snapctl plugin load {}".format(os.path.join(plugin.dir, plugin.name)))
-            loaded = self.binaries.snapctl.load_plugin(plugin)
+            log.info("snaptel plugin load {}".format(os.path.join(plugin.dir, plugin.name)))
+            loaded = self.binaries.snaptel.load_plugin(plugin)
             self.assertTrue(loaded, "{} loaded".format(plugin.name))
 
         # check available metrics, plugins and tasks
-        metrics = self.binaries.snapctl.list_metrics()
-        plugins = self.binaries.snapctl.list_plugins()
-        tasks = self.binaries.snapctl.list_tasks()
+        metrics = self.binaries.snaptel.list_metrics()
+        plugins = self.binaries.snaptel.list_plugins()
+        tasks = self.binaries.snaptel.list_tasks()
         self.assertGreater(len(metrics), 0, "Metrics available {} expected {}".format(len(metrics), 0))
         self.assertEqual(len(plugins), 3, "Plugins available {} expected {}".format(len(plugins), 3))
         self.assertEqual(len(tasks), 0, "Tasks available {} expected {}".format(len(tasks), 0))
 
         # check config policy for metric
-        rules = self.binaries.snapctl.metric_get("/intel/psutil/vm/free")
+        rules = self.binaries.snaptel.metric_get("/intel/psutil/vm/free")
         self.assertEqual(len(rules), 0, "Rules available {} expected {}".format(len(rules), 0))
 
         # create and list available task
-        log.info("snapctl task create -t {}".format(self.task_file))
-        task_id = self.binaries.snapctl.create_task(self.task_file)
-        tasks = self.binaries.snapctl.list_tasks()
+        log.info("snaptel task create -t {}".format(self.task_file))
+        task_id = self.binaries.snaptel.create_task(self.task_file)
+        tasks = self.binaries.snaptel.list_tasks()
         self.assertEqual(len(tasks), 1, "Tasks available {} expected {}".format(len(tasks), 1))
 
         # check if task hits and fails
-        hits = self.binaries.snapctl.task_hits_count(task_id)
-        fails = self.binaries.snapctl.task_fails_count(task_id)
+        hits = self.binaries.snaptel.task_hits_count(task_id)
+        fails = self.binaries.snaptel.task_fails_count(task_id)
         self.assertGreater(hits, 0, "Task hits {} expected {}".format(hits, ">0"))
         self.assertEqual(fails, 0, "Task fails {} expected {}".format(fails, 0))
 
         # stop task and list available tasks
-        log.info("snapctl task stop {}".format(task_id))
-        stopped = self.binaries.snapctl.stop_task(task_id)
+        log.info("snaptel task stop {}".format(task_id))
+        stopped = self.binaries.snaptel.stop_task(task_id)
         self.assertTrue(stopped, "Task stopped")
-        tasks = self.binaries.snapctl.list_tasks()
+        tasks = self.binaries.snaptel.list_tasks()
         self.assertEqual(len(tasks), 1, "Tasks available {} expected {}".format(len(tasks), 1))
 
         # unload plugin, list metrics and plugins
-        log.info("snapctl plugin unload {}".format(self.binaries.collector))
-        self.binaries.snapctl.unload_plugin(self.binaries.collector)
-        metrics = self.binaries.snapctl.list_metrics()
-        plugins = self.binaries.snapctl.list_plugins()
+        log.info("snaptel plugin unload {}".format(self.binaries.collector))
+        self.binaries.snaptel.unload_plugin(self.binaries.collector)
+        metrics = self.binaries.snaptel.list_metrics()
+        plugins = self.binaries.snaptel.list_plugins()
         self.assertEqual(len(metrics), 0, "Metrics available {} expected {}".format(len(metrics), 0))
         self.assertEqual(len(plugins), 2, "Plugins available {} expected {}".format(len(plugins), 2))
 
-        # check for snapd errors
-        self.assertEqual(len(self.binaries.snapd.errors), 0, "Errors found during snapd execution:\n{}"
-                         .format("\n".join(self.binaries.snapd.errors)))
+        # check for snapteld errors
+        self.assertEqual(len(self.binaries.snapteld.errors), 0, "Errors found during snapteld execution:\n{}"
+                         .format("\n".join(self.binaries.snapteld.errors)))
 
     def tearDown(self):
-        log.info("stopping snapd")
-        self.binaries.snapd.stop()
-        if self.binaries.snapd.isAlive():
-            log.warn("snapd thread did not die")
+        log.info("stopping snapteld")
+        self.binaries.snapteld.stop()
+        if self.binaries.snapteld.isAlive():
+            log.warn("snapteld thread did not die")
 
 if __name__ == "__main__":
     test_suite = unittest.TestLoader().loadTestsFromTestCase(PsutilCollectorLargeTest)


### PR DESCRIPTION
Updated Snap binaries references to snaptel/snapteld

Summary of changes:
- snapctl changed to snaptel in large tests and in example
- snapd changed to snapteld in large tests and in example