### PR TITLE
add conntrack_count and conntrack_max

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # File managed by pluginsync
-sudo: false
+sudo: true
 language: go
 go:
 - 1.6.3

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Namespace | Description (optional)
 /intel/psutil/net/[INTERFACE]/errout | total number of errors while sending on given interface
 /intel/psutil/net/[INTERFACE]/packets_recv | number of packets received on given interface
 /intel/psutil/net/[INTERFACE]/packets_sent | number of packets sent on given interface
+/intel/psutil/netfilter/conntrackcount | number of open connection
+/intel/psutil/netfilter/conntrackmax | size of the connection tracking table
 |
 /intel/psutil/vm/active | memory currently in use or very recently used, and so it is in RAM
 /intel/psutil/vm/available | the actual amount of available memory that can be given instantly to processes that request more memory in bytes; this is calculated by summing different memory values depending on the platform (e.g. free + buffers + cached on Linux) and it is supposed to be used to monitor actual memory usage in a cross platform fashion

--- a/glide.lock
+++ b/glide.lock
@@ -23,7 +23,7 @@ imports:
 - name: github.com/robfig/cron
   version: 32d9c273155a0506d27cf73dd1246e86a470997e
 - name: github.com/shirou/gopsutil
-  version: 449c8250b0e837d670b2f9e7337e90ad00514b0c
+  version: bc9d8fac2b735186a17b42f75e394925e9d1d6f7
   subpackages:
   - cpu
   - internal/common

--- a/psutil/net.go
+++ b/psutil/net.go
@@ -62,6 +62,17 @@ var netIOCounterLabels = map[string]label{
 	},
 }
 
+var netConntrackCounterLabels = map[string]label{
+	"conntrackcount": label{
+		unit:        "",
+		description: "",
+	},
+	"conntrackmax": label{
+		unit:        "",
+		description: "",
+	},
+}
+
 func netIOCounters(nss []core.Namespace) ([]plugin.MetricType, error) {
 	// gather accumulated metrics for all interfaces
 	netsAll, err := net.IOCounters(false)
@@ -75,13 +86,20 @@ func netIOCounters(nss []core.Namespace) ([]plugin.MetricType, error) {
 		return nil, err
 	}
 
+	// gather conntrack metric
+	conntrack, err := net.FilterCounters()
+	if err != nil {
+		return nil, err
+	}
+
 	results := []plugin.MetricType{}
 
 	for _, ns := range nss {
 		// set requested metric name from last namespace element
 		metricName := ns.Element(len(ns) - 1).Value
 		// check if requested metric is dynamic (requesting metrics for all nics)
-		if ns[3].Value == "*" {
+		switch ns[3].Value {
+		case "*":
 			for _, net := range netsNic {
 				// prepare namespace copy to update value
 				// this will allow to keep namespace as dynamic (name != "")
@@ -102,7 +120,28 @@ func netIOCounters(nss []core.Namespace) ([]plugin.MetricType, error) {
 				}
 				results = append(results, metric)
 			}
-		} else {
+		case "netfilter":
+			if ns[4].Value == "conntrackcount" {
+				metric := plugin.MetricType{
+					Namespace_: ns,
+					Data_:      conntrack[0].ConnTrackCount,
+					Timestamp_: time.Now(),
+					Unit_:      netConntrackCounterLabels[metricName].unit,
+				}
+				results = append(results, metric)
+			}
+
+			if ns[4].Value == "conntrackmax" {
+				metric := plugin.MetricType{
+					Namespace_: ns,
+					Data_:      conntrack[0].ConnTrackMax,
+					Timestamp_: time.Now(),
+					Unit_:      netConntrackCounterLabels[metricName].unit,
+				}
+				results = append(results, metric)
+			}
+
+		default:
 			stats := append(netsAll, netsNic...)
 			// find stats for interface name or all nics
 			stat := findNetIOStats(stats, ns[3].Value)
@@ -174,6 +213,14 @@ func getNetIOCounterMetricTypes() ([]plugin.MetricType, error) {
 		mts = append(mts, plugin.MetricType{
 			Namespace_: core.NewNamespace("intel", "psutil", "net").
 				AddDynamicElement("nic_id", "network interface id").AddStaticElement(name),
+			Description_: label.description,
+			Unit_:        label.unit,
+		})
+	}
+
+	for name, label := range netConntrackCounterLabels {
+		mts = append(mts, plugin.MetricType{
+			Namespace_:   core.NewNamespace("intel", "psutil", "net", "netfilter", name),
 			Description_: label.description,
 			Unit_:        label.unit,
 		})


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #54

Summary of changes:
- add conntrack_count and conntrack
/intel/psutil/netfilter/conntrackcount
/intel/psutil/netfilter/conntrackmax

How to verify it:
- load task with this metrics:
"/intel/psutil/net/netfilter/conntrackcount": {},
"/intel/psutil/net/netfilter/conntrackmax": {},

Testing done:
-

A picture of a snapping turtle (not required but encouraged):
-