### PR TITLE
Fixes #60: Adds support for building Windows bin

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,15 +40,21 @@ export CGO_ENABLED=0
 _debug "removing: ${build_dir:?}/*"
 rm -rf "${build_dir:?}/"*
 
-_info "building plugin: ${plugin_name}"
+_info "building plugin: ${plugin_name} for Linux"
 export GOOS=linux
 export GOARCH=amd64
 mkdir -p "${build_dir}/${GOOS}/x86_64"
 "${go_build[@]}" -o "${build_dir}/${GOOS}/x86_64/${plugin_name}" . || exit 1
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  export CGO_ENABLED=1
+_info "building plugin: ${plugin_name} for Windows"
+export GOOS=windows
+export GOARCH=amd64
+mkdir -p "${build_dir}/${GOOS}/x86_64"
+"${go_build[@]}" -o "${build_dir}/${GOOS}/x86_64/${plugin_name}.exe" . || exit 1
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+_info "building plugin: ${plugin_name} for Darwin"
+  export CGO_ENABLED=1
   export GOOS=darwin
   export GOARCH=amd64
   mkdir -p "${build_dir}/${GOOS}/x86_64"


### PR DESCRIPTION
Fixes #50

Summary of changes:
- Adds support for building Windows binary

How to verify it:
- run `make`

Testing done:
- manual

![img](https://photos.smugmug.com/Cape-Cod/Cape-Cod-VII-1/i-NdR8BSs/0/L/swimming%20snapping%20turtle-L.jpg)