### PR TITLE
Added HW Address and MTU to the collected networks metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Namespace | Description (optional)
 /intel/psutil/vm/wired | memory that is marked to always stay in RAM. It is never moved to disk
 
 *Please note that there is no possibility to request specific instance of dynamic disk metric passing it via requested metric in task manifest. I collect metrics based on configured mount points
+All collected network counters contains information about the hardware address (tag -> hardware_address) and the MTU (tag -> mtu).
 
 ### Examples
 This is an example running psutil and writing data to a file. It is assumed that you are using the latest Snap binary and plugins.

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	pluginName    = "psutil"
-	pluginVersion = 11
+	pluginVersion = 12
 )
 
 // plugin bootstrap


### PR DESCRIPTION
- Added HW Address and MTU to the collected networks metrics
- nic_id used as a dynamic metric key renamed to the interface_name to unify this key, tag for all network collectors. like psutil, interface. 

