### PR TITLE
Upgrade plugin to recent version of plugin-lib-go

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 09c418cddfe76f4509739130c830fd51fe5289a5fb26bd999171dc83e69f0ac2
-updated: 2017-05-15T08:03:39.934788184-07:00
+updated: 2017-07-10T08:34:42.971358475+02:00
 imports:
 - name: github.com/go-ole/go-ole
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
@@ -10,7 +10,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/intelsdi-x/snap-plugin-lib-go
-  version: d1d32a057c0c23169796016876ce89634b2c012f
+  version: 25d0f6c1ebd320c49b1a8cb2c2b32c6091c43530
   subpackages:
   - v1/plugin
   - v1/plugin/rpc

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	pluginName    = "psutil"
-	pluginVersion = 12
+	pluginVersion = 13
 )
 
 // plugin bootstrap


### PR DESCRIPTION
Allow using plugin standalone on a dedicated host with a proper domain-bound TLS certificate.

Summary of changes:
- upgrade dependency to snap-plugin-lib-go 

How to verify it (testing with [influxdb publisher plugin](https://github.com/intelsdi-x/snap-plugin-publisher-influxdb)):
1. Acquire access to domain names. You may try aliasing loopback address in config file `/etc/hosts`.
1. Obtain test TLS certificates. For a local test you may see [SETUP_TLS_CERTIFICATES.md](/intelsdi-x/snap/blob/master/docs/SETUP_TLS_CERTIFICATES.md#obtaining-self-signed-certificates) in snap repository. Be sure to specify desired domain names instead of `localhost`.
1. Start snap with TLS certificates:
```
snapteld -t 0 -l 1 --tls-cert=/tmp/daemon.example.net-cli.crt --tls-key=/tmp/daemon.example.net-cli.key --ca-cert-paths=/tmp/example.net-ca.crt
```
1. Load necessary plugins:
```
./snap-plugin-collector-psutil --stand-alone --stand-alone-port 8281 --addr collectors.example.net --tls --cert-path /tmp/collectors.example.net-srv.crt --key-path /tmp/collectors.example.net-srv.key --root-cert-paths /tmp/example.net-ca.crt
./snap-plugin-publisher-influxdb --stand-alone --stand-alone-port 8381 --addr collectors.example.net --tls --cert-path /tmp/collectors.example.net-srv.crt --key-path /tmp/collectors.example.net-srv.key --root-cert-paths /tmp/example.net-ca.crt
snaptel plugin load http://collectors.example.net:8281
snaptel plugin load http://collectors.example.net:8381
```
1. Start example [influxdb task](https://github.com/intelsdi-x/snap-plugin-publisher-influxdb/blob/master/examples/tasks/psutil-influxdb-http.yml) (replace INFLUXDB_HOST for actual influxdb hostname).
1. Watch result:
`snaptel task watch <TASK_ID>`

Testing done:
- developer tests

